### PR TITLE
fix: #5 Hardcoded Time Values in Session and OAuth Services

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,10 +42,12 @@ func main() {
 	// Initialize repositories and services
 	userRepo := repository.NewUserRepository(db)
 	userService := service.NewUserService(userRepo)
+	sessionService := service.NewSessionService(rdb, cfg)
+	oauthService := service.NewOAuthService(rdb, cfg)
 
 	// Initialize handlers
 	userHandler := handler.NewUserHandler(userService)
-	authHandler := handler.NewAuthHandler(db, rdb)
+	authHandler := handler.NewAuthHandler(db, rdb, sessionService, oauthService)
 
 	// Define public methods that don't require authentication
 	publicMethods := map[string]bool{

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -7,6 +7,10 @@ jwt_secret = "jwt_secret"
 github_client_id = "github_client_id"
 github_client_secret = "github_client_secret"
 github_redirect_url = "http://localhost:8080/auth/callback"
+oauth_state_expiration_minutes = 10
+
+[session]
+expiration_hours = 24
 
 [redis]
 urls = "localhost:6379"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/oj-lab/user-service
 go 1.24.4
 
 require (
+	github.com/casbin/casbin/v2 v2.108.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-github/v73 v73.0.0
 	github.com/oj-lab/go-webmods v0.1.2
@@ -17,7 +18,6 @@ require (
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
-	github.com/casbin/casbin/v2 v2.108.0 // indirect
 	github.com/casbin/govaluate v1.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+d
 github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=

--- a/internal/utils/token.go
+++ b/internal/utils/token.go
@@ -13,10 +13,14 @@ type UserTokenClaims struct {
 	jwt.MapClaims
 }
 
+// NewUserTokenClaims creates a new UserTokenClaims with a default 24-hour expiration.
+// Deprecated: This function uses a hardcoded 24-hour expiration time.
+// Use NewUserTokenClaimsWithExpiration instead to specify a custom expiration time.
 func NewUserTokenClaims(userID uint64, role model.UserRole) UserTokenClaims {
 	return NewUserTokenClaimsWithExpiration(userID, role, time.Now().Add(24*time.Hour))
 }
 
+// NewUserTokenClaimsWithExpiration creates a new UserTokenClaims with a custom expiration time.
 func NewUserTokenClaimsWithExpiration(userID uint64, role model.UserRole, expiresAt time.Time) UserTokenClaims {
 	return UserTokenClaims{
 		MapClaims: jwt.MapClaims{
@@ -46,11 +50,15 @@ func (c UserTokenClaims) GetSubject() (string, error) {
 	return c.MapClaims.GetSubject()
 }
 
+// NewUserToken creates a new UserToken with a default 24-hour expiration.
+// Deprecated: This function uses a hardcoded 24-hour expiration time.
+// Use NewUserTokenWithExpiration instead to specify a custom expiration time.
 func NewUserToken(userID uint64, role model.UserRole, secret string) (*userpb.UserToken, error) {
 	expiresAt := time.Now().Add(24 * time.Hour)
 	return NewUserTokenWithExpiration(userID, role, secret, expiresAt)
 }
 
+// NewUserTokenWithExpiration creates a new UserToken with a custom expiration time.
 func NewUserTokenWithExpiration(userID uint64, role model.UserRole, secret string, expiresAt time.Time) (*userpb.UserToken, error) {
 	claims := NewUserTokenClaimsWithExpiration(userID, role, expiresAt)
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)


### PR DESCRIPTION
## description
use config.go to read session limit time in .toml files and pass it to session manager
all tests are passed

## related issue
fix- #5  